### PR TITLE
fix:修改发布ios应用商店'在 GitHub 上编辑此页'按钮跳转到安卓文档的错误

### DIFF
--- a/website/src/pages/docs/app-store/ios/index.tsx
+++ b/website/src/pages/docs/app-store/ios/index.tsx
@@ -1,7 +1,7 @@
 import Markdown, { importAll } from '../../../../component/Markdown';
 
 export default class Page extends Markdown {
-  path = "/website/src/pages/docs/app-store/android/README.md";
+  path = "/website/src/pages/docs/app-store/ios/README.md";
   getMarkdown = async () => {
     const md = await import('./README.md');
     // 支持 markdown 中，相对于当前 index.tsx 相对路径引入图片资源


### PR DESCRIPTION
ios应用商店页面，点击'在 GitHub 上编辑此页'按钮会跳转到安卓文档